### PR TITLE
Don't check the taregetos and targetarch

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
 http_archive(
     name = "io_bazel_rules_docker",
@@ -17,11 +17,11 @@ container_repositories()
 http_file(
     name = "glibc",
     sha256 = "573ceb6ad74b919b06bddd7684a29ef75bc9f3741e067fac1414e05c0087d0b6",
-    url = "https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/g/glibc-2.27-8.fc28.x86_64.rpm",
+    urls = ["https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/g/glibc-2.27-8.fc28.x86_64.rpm"],
 )
 
 http_file(
     name = "ca_certificates",
     sha256 = "dfc3d2bf605fbea7db7f018af53fe0563628f788a40cb1e7f84434606b7b6a12",
-    url = "https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/c/ca-certificates-2018.2.22-3.fc28.noarch.rpm",
+    urls = ["https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/c/ca-certificates-2018.2.22-3.fc28.noarch.rpm"],
 )

--- a/rpm/install_rpms.py
+++ b/rpm/install_rpms.py
@@ -40,8 +40,19 @@ def main():
         # Register the RPMs in the database
         for rpm in args.rpm:
             subprocess.check_call(
-                ["rpm", "--nosignature", "--dbpath", rpmdb, "-i", "-v", "--ignoresize", "--nodeps", "--noscripts",
-                 "--notriggers", "--excludepath", "/", rpm])
+                ["rpm",
+                 "--nosignature",
+                 "--dbpath", rpmdb,
+                 "-i",
+                 "-v",
+                 "--ignoresize",
+                 "--ignorearch",
+                 "--ignoreos",
+                 "--nodeps",
+                 "--noscripts",
+                 "--notriggers",
+                 "--excludepath", "/", rpm]
+            )
 
         # Extract the rpms into the shared folder
         for rpm in args.rpm:


### PR DESCRIPTION
RPMs are installed inside a container. It does not make sense to check
if they match the host architecture where bazel is run.