### PR TITLE
Install rpms through fakeroot

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,11 +21,11 @@ container_deps()
 http_file(
     name = "glibc",
     sha256 = "573ceb6ad74b919b06bddd7684a29ef75bc9f3741e067fac1414e05c0087d0b6",
-    urls = ["https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/g/glibc-2.27-8.fc28.x86_64.rpm"],
+    urls = ["https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/x86_64/os/Packages/g/glibc-2.27-8.fc28.x86_64.rpm"],
 )
 
 http_file(
     name = "ca_certificates",
     sha256 = "dfc3d2bf605fbea7db7f018af53fe0563628f788a40cb1e7f84434606b7b6a12",
-    urls = ["https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os/Packages/c/ca-certificates-2018.2.22-3.fc28.noarch.rpm"],
+    urls = ["https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/28/Everything/x86_64/os/Packages/c/ca-certificates-2018.2.22-3.fc28.noarch.rpm"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,9 +2,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
-    strip_prefix = "rules_docker-0.7.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
+    sha256 = "4349f2b0b45c860dd2ffe18802e9f79183806af93ce5921fb12cbd6c07ab69a8",
+    strip_prefix = "rules_docker-0.21.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.21.0/rules_docker-v0.21.0.tar.gz"],
 )
 
 load(
@@ -13,6 +13,10 @@ load(
 )
 
 container_repositories()
+
+load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
+
+container_deps()
 
 http_file(
     name = "glibc",

--- a/test/configs/allinone.yaml
+++ b/test/configs/allinone.yaml
@@ -4,14 +4,22 @@ fileExistenceTests:
   path: '/sbin/ldconfig'
   shouldExist: true
   permissions: '-rwxr-xr-x'
+  uid: 0
+  gid: 0
 - name: 'rpm database file'
   path: '/var/lib/rpm/Packages'
   shouldExist: true
   permissions: '-rw-r--r--'
+  uid: 0
+  gid: 0
 - name: 'readme from ca-certificates'
   path: '/usr/share/pki/ca-trust-source/README'
   shouldExist: true
   permissions: '-rw-r--r--'
+  uid: 0
+  gid: 0
 - name: '/etc/test/foo should be there'
   path: '/etc/test/foo'
   shouldExist: false
+  uid: 0
+  gid: 0


### PR DESCRIPTION
When uncompressing cpio files it's best to keep original permissions, for this to be possible we need to fake the system to make it believe we're running as root, because doing sudo or su would be insane and of course out of the question, let's instead use fakeroot which was created for packing software in particular.

Also had to bump some dependencies like rules_docker so the tests would run against newer versions of bazel, lastly the rpms referenced by the tests are no longer available on the repos but archived so pointing to those instead.