### PR TITLE
fix compatibility with rules_docker >= v0.23

### DIFF
--- a/rpm/rpm.bzl
+++ b/rpm/rpm.bzl
@@ -34,7 +34,7 @@ def _rpms_impl(ctx, rpms = None):
     return _container.image.implementation(ctx, tars = tars)
 
 _rpms_layer = rule(
-    attrs = dict(_container.image.attrs.items() + {
+    attrs = dict([ item for item in _container.image.attrs.items() if item[0] != "_allowlist_function_transition" ]  + {
         # The dependency whose runfiles we're appending.
         "rpms": attr.label_list(allow_files = True, mandatory = True),
         "_rpm_installer": attr.label(


### PR DESCRIPTION
after rules_docker 0.23 supports transitions, an extra `_allowlist_function_transition` is added. however `rules_container_rpm` is not use transitions, and it will cause an `Unused function-based split transition allowlist: @io_bazel_rules_container_rpm//rpm:rpm.bzl NORMAL` error.


FYI: https://bazel.googlesource.com/bazel/+/refs/heads/master/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java#922